### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -1,4 +1,6 @@
 name: Notify Main Repository
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/FaeyUmbrea/ethereal-plane/security/code-scanning/4](https://github.com/FaeyUmbrea/ethereal-plane/security/code-scanning/4)

In general, the fix is to add an explicit `permissions` block to the workflow (either at the top level or within the `notify` job) that restricts the `GITHUB_TOKEN` to the minimal scopes needed. Since this job only calls an external action with a PAT and does not appear to need write access to repository contents, issues, or pull requests, we can set `contents: read` as a safe minimal starting point. If the job truly does not use `GITHUB_TOKEN` at all, `permissions: {}` could be considered, but `contents: read` aligns with GitHub’s recommended minimal baseline.

The best way to fix this without changing existing functionality is to define a workflow-level `permissions` block just below the `name` key, before the `on:` section. This block will apply to all jobs in the workflow, including `notify`, and will ensure `GITHUB_TOKEN` is limited to read-only repository contents. No imports or additional methods are needed, as this is purely a YAML configuration change.

Concretely, in `.github/workflows/update-submodule.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Notify Main Repository`). No changes are needed to the `jobs` or `steps` sections.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
