### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish to Foundry
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/FaeyUmbrea/ethereal-plane/security/code-scanning/3](https://github.com/FaeyUmbrea/ethereal-plane/security/code-scanning/3)

In general, to fix this issue you add an explicit `permissions` block either at the top level of the workflow (applying to all jobs) or within the specific job. The block should grant only the minimal permissions that the workflow actually needs. Since this workflow only checks out the repository and calls an external API using a secret, it does not need any write permissions on the repo; read-only access to contents is sufficient for `actions/checkout`.

The best fix here is to add a `permissions` block at the root level of `.github/workflows/publish.yml`, directly under `name: Publish to Foundry`, setting `contents: read`. This documents the workflow’s needs and ensures `GITHUB_TOKEN` cannot be used to write to the repository from this workflow, even if organization defaults are broader. No other scopes (like `issues`, `pull-requests`, etc.) appear necessary since nothing in the job interacts with them.

Concretely: edit `.github/workflows/publish.yml` and insert:

```yaml
permissions:
  contents: read
```

right after the `name: Publish to Foundry` line. No imports, methods, or other definitions are needed since this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
