### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -2,6 +2,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   github-releases-to-discord:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/FaeyUmbrea/ethereal-plane/security/code-scanning/1](https://github.com/FaeyUmbrea/ethereal-plane/security/code-scanning/1)

In general, fix this by explicitly adding a `permissions:` block specifying the least privileges required. For a workflow that only needs to read repository contents and post to an external service via a secret, `contents: read` is sufficient. This can be defined at the root of the workflow (applies to all jobs) or within the specific job.

For this specific file, the simplest, non-breaking fix is to add a root-level `permissions:` section with `contents: read`. This documents that the workflow only needs read access to repository contents and constrains the `GITHUB_TOKEN` accordingly. Concretely, in `.github/workflows/discord.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 1–3) and the `jobs:` block (line 5). No imports or additional definitions are required, and no changes to the steps themselves are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
