### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   qodana:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.4


### PR DESCRIPTION
Potential fix for [https://github.com/FaeyUmbrea/ethereal-plane/security/code-scanning/2](https://github.com/FaeyUmbrea/ethereal-plane/security/code-scanning/2)

In general, the problem is fixed by explicitly specifying a minimal `permissions` block either at the top level of the workflow (to apply to all jobs) or within the specific job. This ensures the `GITHUB_TOKEN` used by the workflow has only the least privileges required, and is not relying on potentially permissive repository or organization defaults.

For this specific workflow, the simplest and safest fix without altering functionality is to add a `permissions` section granting `contents: read` only. The job checks out the repository and runs `yarn` and `yarn lint`, which only need read access to repository contents. To keep the change minimal and local to the highlighted problem, you can add `permissions: contents: read` under the `qodana` job definition, aligned with the existing indentation. Concretely, edit `.github/workflows/lint.yml` so that under `jobs: qodana:`, before `runs-on: ubuntu-latest`, you add:

```yml
    permissions:
      contents: read
```

No additional methods, imports, or definitions are needed, since this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
